### PR TITLE
Allow Fastly API key to be pulled from environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-aws-fastly",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Deploy for Amazon S3, Fastly configuration",
   "main": "bin/deploy.js",
   "scripts": {

--- a/src/setFastly.js
+++ b/src/setFastly.js
@@ -12,7 +12,7 @@ module.exports = (config, opts) => {
 	let fastly = config.fastly,
 		url = `https://${fastly.url}`,
 		headers = {
-			'Fastly-Key': fastly.api_key,
+			'Fastly-Key': fastly.api_key || process.env.FASTLY_API_KEY,
 			'Content-Type': 'application/json'
 		};
 


### PR DESCRIPTION
The AWS CLI already handles this (if the secrets they need aren't in the configuration then they pull them from the environment), so this enables the last "secret" to be removed from the configuration file.