### PR TITLE
Exit with error code on error

### DIFF
--- a/bin/assign.js
+++ b/bin/assign.js
@@ -43,6 +43,6 @@ let log = require('../src/logging'),
     }, err => {
       log.error(err);
       log.failed(timer.stop());
-      // process.exitCode = 1;
+      process.exit(1);
     });
 

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -49,6 +49,7 @@ let log = require('../src/logging'),
     }, err => {
       log.error(err);
       log.failed(timer.stop());
-      // process.exitCode = 1;
-    });
+      process.exit(1);
+    })
+    
 


### PR DESCRIPTION
Previous incantations would end with a 0 regardless of the presence of failure. This made CI processes mark failed runs as successes.