### PR TITLE
Print stdout on getDist error

### DIFF
--- a/src/getDist.js
+++ b/src/getDist.js
@@ -41,6 +41,11 @@ module.exports = (config, opts) => {
 		return new Promise((resolve, reject) => {
 			cp.exec(cmd, opts || { cwd: config._app_root_path }, (err, stdout, stderr) => {
 				spinner.stop(true);
+
+				if (err) {
+					log.error(stdout);
+				}
+
 				return err ? reject(stderr) : resolve();
 		  });
 		});


### PR DESCRIPTION
If the build process fails this gives additional context. This is especially useful when the `npm run build` command erroneously prints error messaging to stdout instead of stderr.